### PR TITLE
setup gcloud manually 1.5

### DIFF
--- a/.github/workflows/gh-actn-cicd.yaml
+++ b/.github/workflows/gh-actn-cicd.yaml
@@ -57,7 +57,7 @@ jobs:
 
     # setup gcloud
     - name: "Set up Cloud SDK"
-      run: gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS --no-browser
+      run: gcloud auth login --cred-file=$GOOGLE_APPLICATION_CREDENTIALS
 
     # simple test that gcloud is working
     - name: "Use gcloud CLI"


### PR DESCRIPTION
# Overview
- Not sure how --no-browser didn't work when it's in the [docs](https://cloud.google.com/sdk/gcloud/reference/auth/login#--browser) #13 