### PR TITLE
invoking new containers for each request to the frontend cloud run service

### DIFF
--- a/.github/workflows/gh-actn-cicd.yaml
+++ b/.github/workflows/gh-actn-cicd.yaml
@@ -97,7 +97,7 @@ jobs:
       env:
         IAK: ${{ secrets.IDP_API_KEY }}
         IAD: ${{ secrets.IDP_AUTH_DOMAIN }}
-      run: gcloud run deploy ${SERVICE} --platform managed --max-instances=100 --allow-unauthenticated --set-env-vars REACT_APP_GOOGLE_CLOUD_PROJECT=$$GCP_PROJECT,REACT_APP_IDP_API_KEY=$IAK,REACT_APP_IDP_AUTH_DOMAIN=$IAD --image gcr.io/$GCP_PROJECT/$IMAGE_NAME
+      run: gcloud run deploy ${SERVICE} --platform managed --concurrency 1 --min-instances 1 --max-instances=100 --allow-unauthenticated --set-env-vars REACT_APP_GOOGLE_CLOUD_PROJECT=$$GCP_PROJECT,REACT_APP_IDP_API_KEY=$IAK,REACT_APP_IDP_AUTH_DOMAIN=$IAD --image gcr.io/$GCP_PROJECT/$IMAGE_NAME
 
     # deploy cloud functions with firebase-tools 
     # - name: "cloud functions"


### PR DESCRIPTION
[Update]
enhancement:
- enabled service to handle creating container/request
- minimum instance limit of 1﻿
